### PR TITLE
fix(ArtieTransfer): remove potential for data merging

### DIFF
--- a/lib/cdc/event.go
+++ b/lib/cdc/event.go
@@ -30,21 +30,23 @@ type Event interface {
 }
 
 type TableID struct {
-	Schema string
-	Table  string
+	Catalog string
+	Schema  string
+	Table   string
 }
 
-func NewTableID(schema, table string) TableID {
+func NewTableID(catalog, schema, table string) TableID {
 	return TableID{
-		Schema: schema,
-		Table:  table,
+		Catalog: catalog,
+		Schema:  schema,
+		Table:   table,
 	}
 }
 
 func (t TableID) IsEmpty() bool {
-	return t.Schema == "" && t.Table == ""
+	return t.Catalog == "" && t.Schema == "" && t.Table == ""
 }
 
 func (t TableID) String() string {
-	return fmt.Sprintf("%s.%s", t.Schema, t.Table)
+	return fmt.Sprintf("%s.%s.%s", t.Catalog, t.Schema, t.Table)
 }

--- a/lib/config/validate.go
+++ b/lib/config/validate.go
@@ -1,0 +1,83 @@
+package config
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"slices"
+
+	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/kafkalib"
+)
+
+func ValidateMode(mode Mode) error {
+	valid := []Mode{History, Replication}
+	if !slices.Contains(valid, mode) {
+		return fmt.Errorf("invalid mode supplied: %s", mode)
+	}
+	return nil
+}
+
+func ValidateOutputSource(source constants.DestinationKind) error {
+	if !slices.Contains(constants.ValidDestinations, source) {
+		return fmt.Errorf("invalid destination supplied: %s", source)
+	}
+	return nil
+}
+
+func ValidateQueueKind(queue constants.QueueKind) error {
+	valid := []constants.QueueKind{constants.Kafka, constants.Reader}
+	if !slices.Contains(valid, queue) {
+		return fmt.Errorf("invalid queue kind supplied: %s", queue)
+	}
+	return nil
+}
+
+func ValidateTopicConfigs(topicConfigs []*kafkalib.TopicConfig) error {
+	topicHashSet := make(map[string]int)
+	for idx, topicConfig := range topicConfigs {
+		hasher := sha256.New()
+		hasher.Write([]byte(topicConfig.Database))
+		hasher.Write([]byte(topicConfig.Schema))
+		hasher.Write([]byte(topicConfig.TableName))
+		sha := hex.EncodeToString(hasher.Sum(nil))
+		if _, ok := topicHashSet[sha]; !ok {
+			topicHashSet[sha] = idx
+		} else {
+			return fmt.Errorf("topic config at index: %d conflicts with previous: %d, check database, schema and table doen't overlap",
+				idx,
+				topicHashSet[sha],
+			)
+		}
+	}
+	return nil
+}
+
+func ValidateKafka(kafkaConfig *kafkalib.Kafka) error {
+	return ValidateTopicConfigs(kafkaConfig.TopicConfigs)
+}
+
+func ValidateConfig(config Config) error {
+	modeValidation := ValidateMode(config.Mode)
+	if modeValidation != nil {
+		return modeValidation
+	}
+	destinationSource := ValidateOutputSource(config.Output)
+	if destinationSource != nil {
+		return destinationSource
+	}
+	queueKind := ValidateQueueKind(config.Queue)
+	if queueKind != nil {
+		return queueKind
+	}
+	topicConfigs := ValidateTopicConfigs(config.Kafka.TopicConfigs)
+	if topicConfigs != nil {
+		return topicConfigs
+	}
+
+	return nil
+}
+
+func ValidateSettings(settings *Settings) error {
+	return ValidateConfig(settings.Config)
+}

--- a/lib/config/validate_test.go
+++ b/lib/config/validate_test.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/artie-labs/transfer/lib/kafkalib"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateTopicConfigs(t *testing.T) {
+	// ensure duplication is picked up
+	input := []*kafkalib.TopicConfig{}
+
+	config := &kafkalib.TopicConfig{
+		Database:  "database",
+		Schema:    "schema",
+		TableName: "table",
+	}
+	input = append(input, config)
+
+	input = append(input, config)
+
+	err := ValidateTopicConfigs(input)
+	assert.NotEmpty(t, input)
+	assert.Error(t, err)
+}

--- a/lib/kafkalib/connection.go
+++ b/lib/kafkalib/connection.go
@@ -30,7 +30,7 @@ type Connection struct {
 	disableTLS      bool
 	username        string
 	password        string
-  saslMechanism   string
+	saslMechanism   string
 
 	timeout time.Duration
 }

--- a/main.go
+++ b/main.go
@@ -31,6 +31,10 @@ func main() {
 	if err != nil {
 		logger.Fatal("Failed to initialize config", slog.Any("err", err))
 	}
+	validationError := config.ValidateSettings(settings)
+	if validationError != nil {
+		logger.Fatal("Config validation failed", slog.Any("err", validationError))
+	}
 
 	// Initialize default logger
 	_logger, cleanUpHandlers := logger.NewLogger(settings.VerboseLogging, settings.Config.Reporting.Sentry, version)

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -223,7 +223,7 @@ func ToMemoryEvent(event cdc.Event, pkMap map[string]any, tc kafkalib.TopicConfi
 		// [primaryKeys] needs to be sorted so that we have a deterministic way to identify a row in our in-memory db.
 		primaryKeys:    pks,
 		table:          tblName,
-		tableID:        cdc.NewTableID(tc.Schema, tblName),
+		tableID:        cdc.NewTableID(tc.Database, tc.Schema, tblName),
 		optionalSchema: optionalSchema,
 		columns:        cols,
 		data:           transformData(evtData, tc),

--- a/models/memory.go
+++ b/models/memory.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -75,6 +77,19 @@ func (d *DatabaseData) GetOrCreateTableData(tableID cdc.TableID, topic string) *
 		}
 
 		d.tableData[tableID] = table
+	}
+
+	if d.tableData[tableID].topic != topic {
+		// not checking for this scenario can result in data corruption
+		slog.Error("cannot create memory table for given table id because topic does not correspond to existing topic",
+			slog.Any("existing topic", d.tableData[tableID].topic),
+			slog.Any("given topic", topic),
+			slog.Any("table id", tableID),
+		)
+		panic(fmt.Errorf("cannot create memory table for conflicting topic: existing '%s', given '%s'",
+			d.tableData[tableID].topic,
+			topic,
+		))
 	}
 
 	return d.tableData[tableID]

--- a/models/memory_test.go
+++ b/models/memory_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestTableData_Complete(t *testing.T) {
 	db := NewMemoryDB()
-	tableID := cdc.NewTableID("schema", "table")
+	tableID := cdc.NewTableID("database", "schema", "table")
 	{
 		// Does not exist
 		_, ok := db.TableData()[tableID]

--- a/processes/consumer/flush_test.go
+++ b/processes/consumer/flush_test.go
@@ -27,7 +27,7 @@ var topicConfig = kafkalib.TopicConfig{
 func (f *FlushTestSuite) TestMemoryBasic() {
 	mockEvent := &mocks.FakeEvent{}
 	mockEvent.GetTableNameReturns(topicConfig.TableName)
-	expectedTableID := cdc.NewTableID(topicConfig.Schema, topicConfig.TableName)
+	expectedTableID := cdc.NewTableID(topicConfig.Database, topicConfig.Schema, topicConfig.TableName)
 
 	for i := range 5 {
 		mockEvent.GetDataReturns(map[string]any{
@@ -86,9 +86,9 @@ func (f *FlushTestSuite) TestShouldFlush() {
 
 func (f *FlushTestSuite) TestMemoryConcurrency() {
 	tableIDs := []cdc.TableID{
-		cdc.NewTableID("public", "dusty"),
-		cdc.NewTableID("public", "snowflake"),
-		cdc.NewTableID("public", "postgres"),
+		cdc.NewTableID("database", "public", "dusty"),
+		cdc.NewTableID("database", "public", "snowflake"),
+		cdc.NewTableID("database", "public", "postgres"),
 	}
 	var wg sync.WaitGroup
 
@@ -109,7 +109,7 @@ func (f *FlushTestSuite) TestMemoryConcurrency() {
 					"cat":                               "dog",
 				}, nil)
 
-				evt, err := event.ToMemoryEvent(mockEvent, map[string]any{"id": fmt.Sprintf("pk-%d", i)}, kafkalib.TopicConfig{Schema: tableID.Schema, Topic: topicConfig.Topic}, config.Replication)
+				evt, err := event.ToMemoryEvent(mockEvent, map[string]any{"id": fmt.Sprintf("pk-%d", i)}, kafkalib.TopicConfig{Database: tableID.Catalog, Schema: tableID.Schema, Topic: topicConfig.Topic}, config.Replication)
 				assert.NoError(f.T(), err)
 
 				kafkaMsg := kafka.Message{Partition: 1, Offset: int64(i)}

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -22,7 +22,7 @@ var (
 	db      = "lemonade"
 	schema  = "public"
 	table   = "orders"
-	tableID = cdc.NewTableID(schema, table)
+	tableID = cdc.NewTableID(db, schema, table)
 )
 
 func TestProcessMessageFailures(t *testing.T) {


### PR DESCRIPTION
The in memory database used TableID to as its key. This structure unfortunately only uses the Schema and TableName which has created a situation where two topics end up being merged into the same destination if these values are identical.

Consequently, added config validation as well as a runtime check to prevent data corruption. Also, extended TableID to take into account destination database/catalog to reduce chance of unintentional duplication.